### PR TITLE
Add brandable job management improvements

### DIFF
--- a/job_manager/app.py
+++ b/job_manager/app.py
@@ -1,9 +1,16 @@
-from flask import Flask, request, redirect, url_for, render_template_string
+from flask import Flask, request, redirect, url_for, render_template, flash
 import sqlite3
 from datetime import datetime
+import os
 
 app = Flask(__name__)
+app.secret_key = 'change-me'
 DB_NAME = 'data.db'
+BRAND = os.environ.get('APP_BRAND', 'HireSoft')
+
+@app.context_processor
+def inject_brand():
+    return {'brand': BRAND}
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS jobs (
@@ -39,16 +46,66 @@ def index():
     jobs = con.execute('SELECT * FROM jobs').fetchall()
     hires = con.execute('SELECT * FROM hires').fetchall()
     con.close()
-    return render_template_string(TEMPL_INDEX, jobs=jobs, hires=hires)
+    return render_template('index.html', jobs=jobs, hires=hires)
 
 @app.route('/job/add', methods=['POST'])
 def add_job():
     name = request.form['name']
     description = request.form.get('description','')
     con = sqlite3.connect(DB_NAME)
-    con.execute('INSERT INTO jobs (name, description) VALUES (?,?)', (name, description))
+    con.execute('INSERT INTO jobs (name, description) VALUES (?, ?)', (name, description))
     con.commit()
     con.close()
+    return redirect(url_for('index'))
+
+
+@app.route('/job/<int:job_id>')
+def job_detail(job_id):
+    con = sqlite3.connect(DB_NAME)
+    con.row_factory = sqlite3.Row
+    job = con.execute('SELECT * FROM jobs WHERE id=?', (job_id,)).fetchone()
+    hires = con.execute('SELECT * FROM hires WHERE job_id=?', (job_id,)).fetchall()
+    con.close()
+    if not job:
+        flash('Job not found')
+        return redirect(url_for('index'))
+    return render_template('job_detail.html', job=job, hires=hires)
+
+
+@app.route('/job/<int:job_id>/close', methods=['POST'])
+def close_job(job_id):
+    con = sqlite3.connect(DB_NAME)
+    con.execute("UPDATE jobs SET status='Closed' WHERE id=?", (job_id,))
+    con.commit()
+    con.close()
+    flash('Job closed')
+    return redirect(url_for('job_detail', job_id=job_id))
+
+
+@app.route('/job/<int:job_id>/delete', methods=['POST'])
+def delete_job(job_id):
+    con = sqlite3.connect(DB_NAME)
+    con.execute('DELETE FROM hires WHERE job_id=?', (job_id,))
+    con.execute('DELETE FROM jobs WHERE id=?', (job_id,))
+    con.commit()
+    con.close()
+    flash('Job deleted')
+    return redirect(url_for('index'))
+
+
+@app.route('/hire/<int:hire_id>/delete', methods=['POST'])
+def delete_hire(hire_id):
+    con = sqlite3.connect(DB_NAME)
+    cur = con.cursor()
+    job_id = cur.execute('SELECT job_id FROM hires WHERE id=?', (hire_id,)).fetchone()
+    if job_id:
+        job_id = job_id[0]
+    cur.execute('DELETE FROM hires WHERE id=?', (hire_id,))
+    con.commit()
+    con.close()
+    flash('Hire deleted')
+    if job_id:
+        return redirect(url_for('job_detail', job_id=job_id))
     return redirect(url_for('index'))
 
 @app.route('/job/<int:job_id>/hire', methods=['POST'])
@@ -57,60 +114,34 @@ def add_hire(job_id):
     rate = float(request.form['rate'])
     on_hire = request.form['on_hire']
     con = sqlite3.connect(DB_NAME)
-    con.execute('INSERT INTO hires (job_id, item_name, daily_rate, on_hire) VALUES (?,?,?,?)', (job_id,item,rate,on_hire))
+    con.execute(
+        'INSERT INTO hires (job_id, item_name, daily_rate, on_hire) VALUES (?,?,?,?)',
+        (job_id, item, rate, on_hire),
+    )
     con.commit()
     con.close()
-    return redirect(url_for('index'))
+    return redirect(url_for('job_detail', job_id=job_id))
 
 @app.route('/hire/<int:hire_id>/off', methods=['POST'])
 def off_hire(hire_id):
     off_date = request.form['off_hire']
     con = sqlite3.connect(DB_NAME)
     cur = con.cursor()
-    hire = cur.execute('SELECT on_hire, daily_rate FROM hires WHERE id=?', (hire_id,)).fetchone()
-    days = (datetime.fromisoformat(off_date) - datetime.fromisoformat(hire[0])).days + 1
-    cost = days * hire[1]
-    cur.execute('UPDATE hires SET off_hire=?, cost=? WHERE id=?', (off_date,cost,hire_id))
+    hire = cur.execute(
+        'SELECT job_id, on_hire, daily_rate FROM hires WHERE id=?', (hire_id,)
+    ).fetchone()
+    job_id = hire[0]
+    days = (datetime.fromisoformat(off_date) - datetime.fromisoformat(hire[1])).days + 1
+    cost = days * hire[2]
+    cur.execute(
+        'UPDATE hires SET off_hire=?, cost=? WHERE id=?', (off_date, cost, hire_id)
+    )
     con.commit()
     con.close()
-    return redirect(url_for('index'))
+    flash('Hire closed. Total cost £{:.2f}'.format(cost))
+    return redirect(url_for('job_detail', job_id=job_id))
 
-TEMPL_INDEX = """
-<!doctype html>
-<title>Job Management</title>
-<h1>Jobs</h1>
-<form method=post action="/job/add">
-Name: <input name=name required>
-Description: <input name=description>
-<input type=submit value="Add Job">
-</form>
-{% for j in jobs %}
-  <h2>{{j['name']}} - {{j['status']}}</h2>
-  <p>{{j['description']}}</p>
-  <h3>Hire Items</h3>
-  <ul>
-  {% for h in hires %}
-    {% if h['job_id']==j['id'] %}
-      <li>{{h['item_name']}} @ {{h['daily_rate']}}/day from {{h['on_hire']}} to {{h['off_hire'] or 'ongoing'}} cost: {{h['cost'] or 'TBD'}}
-        {% if not h['off_hire'] %}
-          <form style="display:inline" method=post action="/hire/{{h['id']}}/off">
-          Off-hire date: <input name=off_hire type=date required>
-          <input type=submit value="Close">
-          </form>
-        {% endif %}
-      </li>
-    {% endif %}
-  {% endfor %}
-  </ul>
-  <form method=post action="/job/{{j['id']}}/hire">
-  Item: <input name=item required>
-  Rate per day: <input name=rate type=number step=0.01 required>
-  On-hire date: <input name=on_hire type=date required>
-  <input type=submit value="Add Hire">
-  </form>
-{% endfor %}
-"""
 init_db()
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=8080, debug=True)
+    app.run(host="0.0.0.0", port=8080, debug=True)

--- a/job_manager/static/css/style.css
+++ b/job_manager/static/css/style.css
@@ -1,0 +1,11 @@
+body {
+  padding-bottom: 50px;
+}
+
+.navbar-dark {
+  background: linear-gradient(90deg, #004880, #0076d1);
+}
+
+.card {
+  box-shadow: 0 0.25rem 0.5rem rgba(0,0,0,0.1);
+}

--- a/job_manager/templates/base.html
+++ b/job_manager/templates/base.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}{{ brand }}{% endblock %}</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('index') }}">{{ brand }}</a>
+  </div>
+</nav>
+<div class="container">
+{% with messages = get_flashed_messages() %}
+  {% if messages %}
+    <div class="alert alert-info">
+      {{ messages[0] }}
+    </div>
+  {% endif %}
+{% endwith %}
+{% block content %}{% endblock %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/job_manager/templates/index.html
+++ b/job_manager/templates/index.html
@@ -1,0 +1,76 @@
+{% extends 'base.html' %}
+{% block title %}Jobs - {{ brand }}{% endblock %}
+{% block content %}
+<h1 class="mb-4">Jobs</h1>
+<form class="row gy-2 mb-4" method="post" action="{{ url_for('add_job') }}">
+  <div class="col-sm-4">
+    <input name="name" class="form-control" placeholder="Job name" required>
+  </div>
+  <div class="col-sm-6">
+    <input name="description" class="form-control" placeholder="Description">
+  </div>
+  <div class="col-sm-2">
+    <button class="btn btn-primary w-100" type="submit">Add Job</button>
+  </div>
+</form>
+{% for j in jobs %}
+  <div class="card mb-4">
+    <div class="card-body">
+<h5 class="card-title">
+  <a href="{{ url_for('job_detail', job_id=j['id']) }}" class="link-dark text-decoration-none">{{ j['name'] }}</a>
+  <small class="text-muted">- {{ j['status'] }}</small>
+</h5>
+<p class="card-text">{{ j['description'] }}</p>
+<div class="mb-2">
+  {% if j['status'] != 'Closed' %}
+    <form class="d-inline" method="post" action="{{ url_for('close_job', job_id=j['id']) }}">
+      <button class="btn btn-sm btn-warning" type="submit">Close Job</button>
+    </form>
+  {% endif %}
+  <form class="d-inline" method="post" action="{{ url_for('delete_job', job_id=j['id']) }}" onsubmit="return confirm('Delete this job and all hires?');">
+    <button class="btn btn-sm btn-danger" type="submit">Delete</button>
+  </form>
+</div>
+      <h6>Hire Items</h6>
+      <ul class="list-group mb-3">
+      {% for h in hires %}
+        {% if h['job_id']==j['id'] %}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            <span>
+              {{ h['item_name'] }} &ndash; £{{ '%.2f'|format(h['daily_rate']) }}/day
+              from {{ h['on_hire'] }} to {{ h['off_hire'] or 'ongoing' }}
+            </span>
+            <span class="badge bg-secondary">{{ h['cost'] and ('£%.2f'|format(h['cost'])) or 'TBD' }}</span>
+            {% if not h['off_hire'] %}
+              <form class="d-flex ms-3" method="post" action="{{ url_for('off_hire', hire_id=h['id']) }}">
+                <input name="off_hire" type="date" class="form-control form-control-sm me-2" required>
+                <button class="btn btn-sm btn-outline-success" type="submit">Close</button>
+              </form>
+            {% endif %}
+          </li>
+        {% endif %}
+      {% endfor %}
+      </ul>
+      <form class="row gy-2" method="post" action="{{ url_for('add_hire', job_id=j['id']) }}">
+        <div class="col-md-4">
+          <input name="item" class="form-control" placeholder="Item" required>
+        </div>
+        <div class="col-md-3">
+          <div class="input-group">
+            <span class="input-group-text">£</span>
+            <input name="rate" type="number" step="0.01" min="0" class="form-control" placeholder="Rate" required>
+          </div>
+        </div>
+        <div class="col-md-3">
+          <input name="on_hire" type="date" class="form-control" required>
+        </div>
+        <div class="col-md-2">
+          <button class="btn btn-secondary w-100" type="submit">Add Hire</button>
+        </div>
+      </form>
+    </div>
+  </div>
+{% else %}
+  <p>No jobs found.</p>
+{% endfor %}
+{% endblock %}

--- a/job_manager/templates/job_detail.html
+++ b/job_manager/templates/job_detail.html
@@ -1,0 +1,50 @@
+{% extends 'base.html' %}
+{% block title %}{{ job['name'] }} - {{ brand }}{% endblock %}
+{% block content %}
+<a class="btn btn-link mb-3" href="{{ url_for('index') }}">&larr; Back to jobs</a>
+<h2>{{ job['name'] }} <small class="text-muted">- {{ job['status'] }}</small></h2>
+<p>{{ job['description'] }}</p>
+{% if job['status'] != 'Closed' %}
+  <form class="mb-3" method="post" action="{{ url_for('close_job', job_id=job['id']) }}">
+    <button class="btn btn-warning" type="submit">Close Job</button>
+  </form>
+{% endif %}
+<h4>Hire Items</h4>
+<ul class="list-group mb-3">
+{% for h in hires %}
+  <li class="list-group-item d-flex justify-content-between align-items-center">
+    <span>
+      {{ h['item_name'] }} &ndash; £{{ '%.2f'|format(h['daily_rate']) }}/day
+      from {{ h['on_hire'] }} to {{ h['off_hire'] or 'ongoing' }}
+    </span>
+    <span class="badge bg-secondary">{{ h['cost'] and ('£%.2f'|format(h['cost'])) or 'TBD' }}</span>
+    {% if not h['off_hire'] %}
+      <form class="d-flex ms-3" method="post" action="{{ url_for('off_hire', hire_id=h['id']) }}">
+        <input name="off_hire" type="date" class="form-control form-control-sm me-2" required>
+        <button class="btn btn-sm btn-outline-success me-2" type="submit">Close</button>
+      </form>
+    {% endif %}
+    <form class="d-flex" method="post" action="{{ url_for('delete_hire', hire_id=h['id']) }}" onsubmit="return confirm('Delete this hire?');">
+      <button class="btn btn-sm btn-outline-danger" type="submit">Delete</button>
+    </form>
+  </li>
+{% endfor %}
+</ul>
+<form class="row gy-2" method="post" action="{{ url_for('add_hire', job_id=job['id']) }}">
+  <div class="col-md-4">
+    <input name="item" class="form-control" placeholder="Item" required>
+  </div>
+  <div class="col-md-3">
+    <div class="input-group">
+      <span class="input-group-text">£</span>
+      <input name="rate" type="number" step="0.01" min="0" class="form-control" placeholder="Rate" required>
+    </div>
+  </div>
+  <div class="col-md-3">
+    <input name="on_hire" type="date" class="form-control" required>
+  </div>
+  <div class="col-md-2">
+    <button class="btn btn-secondary w-100" type="submit">Add Hire</button>
+  </div>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- make templates display a configurable brand name
- add job detail page with options to close or delete jobs and hires
- route hire actions back to their job pages
- add light styling for navbar and cards

## Testing
- `python3 -m py_compile job_manager/app.py`
- `python3 job_manager/app.py >/tmp/app.log 2>&1 &`

------
https://chatgpt.com/codex/tasks/task_e_688cd14c3f74832cbbe1a12fb14ca38b