### PR TITLE
Add README and env-based secret key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# HireSoft Job Manager
+
+This repository contains a small Flask application for managing equipment hire jobs. It is intended as a white‑label solution – the displayed brand name and secret key can be configured through environment variables.
+
+## Requirements
+
+- Python 3.10 or newer
+- The Python packages in `job_manager/requirements.txt`
+
+## Setup
+
+1. **Install dependencies**
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   pip install -r job_manager/requirements.txt
+   ```
+2. **Set environment variables**
+   - `APP_BRAND` – optional brand name shown in the UI (default: `HireSoft`)
+   - `APP_SECRET_KEY` – secret key for session security (provide your own value in production)
+
+3. **Run the app**
+   ```bash
+   python job_manager/app.py
+   ```
+   The server starts on http://localhost:8080/ and automatically creates `data.db` for storage.
+
+## Deployment notes
+
+For production deployments consider running the app with a WSGI server such as Gunicorn or hosting it in a Docker container. The bundled `omnorgroup-theme.zip` can be deployed separately if you also need the WordPress theme.

--- a/job_manager/static/css/style.css
+++ b/job_manager/static/css/style.css
@@ -1,0 +1,11 @@
+body {
+  padding-bottom: 50px;
+}
+
+.navbar-dark {
+  background: linear-gradient(90deg, #004880, #0076d1);
+}
+
+.card {
+  box-shadow: 0 0.25rem 0.5rem rgba(0,0,0,0.1);
+}

--- a/job_manager/templates/base.html
+++ b/job_manager/templates/base.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}{{ brand }}{% endblock %}</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('index') }}">{{ brand }}</a>
+  </div>
+</nav>
+<div class="container">
+{% with messages = get_flashed_messages() %}
+  {% if messages %}
+    <div class="alert alert-info">
+      {{ messages[0] }}
+    </div>
+  {% endif %}
+{% endwith %}
+{% block content %}{% endblock %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/job_manager/templates/index.html
+++ b/job_manager/templates/index.html
@@ -1,0 +1,76 @@
+{% extends 'base.html' %}
+{% block title %}Jobs - {{ brand }}{% endblock %}
+{% block content %}
+<h1 class="mb-4">Jobs</h1>
+<form class="row gy-2 mb-4" method="post" action="{{ url_for('add_job') }}">
+  <div class="col-sm-4">
+    <input name="name" class="form-control" placeholder="Job name" required>
+  </div>
+  <div class="col-sm-6">
+    <input name="description" class="form-control" placeholder="Description">
+  </div>
+  <div class="col-sm-2">
+    <button class="btn btn-primary w-100" type="submit">Add Job</button>
+  </div>
+</form>
+{% for j in jobs %}
+  <div class="card mb-4">
+    <div class="card-body">
+<h5 class="card-title">
+  <a href="{{ url_for('job_detail', job_id=j['id']) }}" class="link-dark text-decoration-none">{{ j['name'] }}</a>
+  <small class="text-muted">- {{ j['status'] }}</small>
+</h5>
+<p class="card-text">{{ j['description'] }}</p>
+<div class="mb-2">
+  {% if j['status'] != 'Closed' %}
+    <form class="d-inline" method="post" action="{{ url_for('close_job', job_id=j['id']) }}">
+      <button class="btn btn-sm btn-warning" type="submit">Close Job</button>
+    </form>
+  {% endif %}
+  <form class="d-inline" method="post" action="{{ url_for('delete_job', job_id=j['id']) }}" onsubmit="return confirm('Delete this job and all hires?');">
+    <button class="btn btn-sm btn-danger" type="submit">Delete</button>
+  </form>
+</div>
+      <h6>Hire Items</h6>
+      <ul class="list-group mb-3">
+      {% for h in hires %}
+        {% if h['job_id']==j['id'] %}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            <span>
+              {{ h['item_name'] }} &ndash; £{{ '%.2f'|format(h['daily_rate']) }}/day
+              from {{ h['on_hire'] }} to {{ h['off_hire'] or 'ongoing' }}
+            </span>
+            <span class="badge bg-secondary">{{ h['cost'] and ('£%.2f'|format(h['cost'])) or 'TBD' }}</span>
+            {% if not h['off_hire'] %}
+              <form class="d-flex ms-3" method="post" action="{{ url_for('off_hire', hire_id=h['id']) }}">
+                <input name="off_hire" type="date" class="form-control form-control-sm me-2" required>
+                <button class="btn btn-sm btn-outline-success" type="submit">Close</button>
+              </form>
+            {% endif %}
+          </li>
+        {% endif %}
+      {% endfor %}
+      </ul>
+      <form class="row gy-2" method="post" action="{{ url_for('add_hire', job_id=j['id']) }}">
+        <div class="col-md-4">
+          <input name="item" class="form-control" placeholder="Item" required>
+        </div>
+        <div class="col-md-3">
+          <div class="input-group">
+            <span class="input-group-text">£</span>
+            <input name="rate" type="number" step="0.01" min="0" class="form-control" placeholder="Rate" required>
+          </div>
+        </div>
+        <div class="col-md-3">
+          <input name="on_hire" type="date" class="form-control" required>
+        </div>
+        <div class="col-md-2">
+          <button class="btn btn-secondary w-100" type="submit">Add Hire</button>
+        </div>
+      </form>
+    </div>
+  </div>
+{% else %}
+  <p>No jobs found.</p>
+{% endfor %}
+{% endblock %}

--- a/job_manager/templates/job_detail.html
+++ b/job_manager/templates/job_detail.html
@@ -1,0 +1,50 @@
+{% extends 'base.html' %}
+{% block title %}{{ job['name'] }} - {{ brand }}{% endblock %}
+{% block content %}
+<a class="btn btn-link mb-3" href="{{ url_for('index') }}">&larr; Back to jobs</a>
+<h2>{{ job['name'] }} <small class="text-muted">- {{ job['status'] }}</small></h2>
+<p>{{ job['description'] }}</p>
+{% if job['status'] != 'Closed' %}
+  <form class="mb-3" method="post" action="{{ url_for('close_job', job_id=job['id']) }}">
+    <button class="btn btn-warning" type="submit">Close Job</button>
+  </form>
+{% endif %}
+<h4>Hire Items</h4>
+<ul class="list-group mb-3">
+{% for h in hires %}
+  <li class="list-group-item d-flex justify-content-between align-items-center">
+    <span>
+      {{ h['item_name'] }} &ndash; £{{ '%.2f'|format(h['daily_rate']) }}/day
+      from {{ h['on_hire'] }} to {{ h['off_hire'] or 'ongoing' }}
+    </span>
+    <span class="badge bg-secondary">{{ h['cost'] and ('£%.2f'|format(h['cost'])) or 'TBD' }}</span>
+    {% if not h['off_hire'] %}
+      <form class="d-flex ms-3" method="post" action="{{ url_for('off_hire', hire_id=h['id']) }}">
+        <input name="off_hire" type="date" class="form-control form-control-sm me-2" required>
+        <button class="btn btn-sm btn-outline-success me-2" type="submit">Close</button>
+      </form>
+    {% endif %}
+    <form class="d-flex" method="post" action="{{ url_for('delete_hire', hire_id=h['id']) }}" onsubmit="return confirm('Delete this hire?');">
+      <button class="btn btn-sm btn-outline-danger" type="submit">Delete</button>
+    </form>
+  </li>
+{% endfor %}
+</ul>
+<form class="row gy-2" method="post" action="{{ url_for('add_hire', job_id=job['id']) }}">
+  <div class="col-md-4">
+    <input name="item" class="form-control" placeholder="Item" required>
+  </div>
+  <div class="col-md-3">
+    <div class="input-group">
+      <span class="input-group-text">£</span>
+      <input name="rate" type="number" step="0.01" min="0" class="form-control" placeholder="Rate" required>
+    </div>
+  </div>
+  <div class="col-md-3">
+    <input name="on_hire" type="date" class="form-control" required>
+  </div>
+  <div class="col-md-2">
+    <button class="btn btn-secondary w-100" type="submit">Add Hire</button>
+  </div>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow configuring the Flask secret key via `APP_SECRET_KEY`
- document setup and deployment notes in a new README

## Testing
- `python3 -m py_compile job_manager/app.py`
- `python3 job_manager/app.py >/tmp/app.log 2>&1 &`

------
https://chatgpt.com/codex/tasks/task_e_688cd14c3f74832cbbe1a12fb14ca38b