### PR TITLE
Add quote and order management backend

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,87 @@
+from flask import Flask, request, jsonify, send_file
+
+from quote_manager.database import Base, engine, SessionLocal
+from quote_manager.models import Supplier, Product, Quote, QuoteItem, ChecklistItem
+from quote_manager.delivery_note import generate_delivery_note
+
+app = Flask(__name__)
+
+# Create tables if not exist
+Base.metadata.create_all(bind=engine)
+
+
+@app.post('/suppliers')
+def add_supplier():
+    data = request.get_json()
+    session = SessionLocal()
+    supplier = Supplier(name=data['name'])
+    session.add(supplier)
+    session.commit()
+    return jsonify({'id': supplier.id})
+
+
+@app.post('/products')
+def add_product():
+    data = request.get_json()
+    session = SessionLocal()
+    product = Product(
+        supplier_id=data['supplier_id'],
+        sku=data['sku'],
+        description=data.get('description'),
+        price=data.get('price', 0),
+        lead_time=data.get('lead_time', 0)
+    )
+    session.add(product)
+    session.commit()
+    return jsonify({'id': product.id})
+
+
+@app.post('/quotes')
+def create_quote():
+    data = request.get_json()
+    session = SessionLocal()
+    quote = Quote(
+        request_id=data.get('request_id'),
+        status=data.get('status', 'draft'),
+        value=data.get('value', 0),
+        margin=data.get('margin', 0),
+        pdf_link=data.get('pdf_link')
+    )
+    session.add(quote)
+    session.flush()
+    for item in data.get('items', []):
+        qi = QuoteItem(
+            quote_id=quote.id,
+            product_id=item['product_id'],
+            quantity=item.get('quantity', 1)
+        )
+        session.add(qi)
+    session.commit()
+    return jsonify({'id': quote.id})
+
+
+@app.post('/quotes/<int:quote_id>/status')
+def update_quote_status(quote_id):
+    session = SessionLocal()
+    quote = session.get(Quote, quote_id)
+    if not quote:
+        return {'error': 'not found'}, 404
+    data = request.get_json()
+    quote.status = data['status']
+    session.commit()
+    if data['status'] == 'ordered':
+        for item in quote.items:
+            session.add(ChecklistItem(quote_item_id=item.id))
+        session.commit()
+    return {'status': quote.status}
+
+
+@app.get('/quotes/<int:quote_id>/delivery_note')
+def get_delivery_note(quote_id):
+    item_ids = request.args.getlist('item_id', type=int)
+    filename = generate_delivery_note(quote_id, item_ids or None)
+    return send_file(filename, as_attachment=True)
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8080)

--- a/quote_manager/__init__.py
+++ b/quote_manager/__init__.py
@@ -1,0 +1,1 @@
+# Quote management package

--- a/quote_manager/database.py
+++ b/quote_manager/database.py
@@ -1,0 +1,6 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+engine = create_engine('sqlite:///data.db', echo=False, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False)
+Base = declarative_base()

--- a/quote_manager/delivery_note.py
+++ b/quote_manager/delivery_note.py
@@ -1,0 +1,27 @@
+from fpdf import FPDF
+from .database import SessionLocal
+from .models import Quote
+
+
+def generate_delivery_note(quote_id, item_ids=None, filename='delivery_note.pdf'):
+    session = SessionLocal()
+    quote = session.get(Quote, quote_id)
+    if not quote:
+        session.close()
+        raise ValueError('Quote not found')
+
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font('Arial', size=12)
+    pdf.cell(0, 10, f'Delivery Note for Quote {quote.id}', ln=1)
+    pdf.cell(0, 10, f'Status: {quote.status}', ln=1)
+    pdf.ln(5)
+    items = quote.items
+    if item_ids:
+        items = [it for it in items if it.id in item_ids]
+    for item in items:
+        prod = item.product
+        pdf.cell(0, 10, f'{prod.sku} - {prod.description} x {item.quantity}', ln=1)
+    pdf.output(filename)
+    session.close()
+    return filename

--- a/quote_manager/email_watcher.py
+++ b/quote_manager/email_watcher.py
@@ -1,0 +1,59 @@
+import imaplib
+import email
+import os
+from typing import List
+
+from .database import SessionLocal
+from .models import QuoteRequest, Attachment
+
+
+def watch_inbox():
+    """Check the IMAP inbox for unseen messages and store them."""
+    host = os.environ.get('IMAP_HOST')
+    user = os.environ.get('IMAP_USER')
+    password = os.environ.get('IMAP_PASS')
+    if not all([host, user, password]):
+        raise RuntimeError('IMAP credentials not set')
+
+    mail = imaplib.IMAP4_SSL(host)
+    mail.login(user, password)
+    mail.select('inbox')
+    status, messages = mail.search(None, '(UNSEEN)')
+
+    session = SessionLocal()
+    attach_dir = 'attachments'
+    os.makedirs(attach_dir, exist_ok=True)
+
+    for num in messages[0].split():
+        status, msg_data = mail.fetch(num, '(RFC822)')
+        msg = email.message_from_bytes(msg_data[0][1])
+        sender = msg.get('From')
+        subject = msg.get('Subject')
+        body = ''
+        files: List[Attachment] = []
+        if msg.is_multipart():
+            for part in msg.walk():
+                ctype = part.get_content_type()
+                disp = str(part.get('Content-Disposition'))
+                if ctype == 'text/plain' and 'attachment' not in disp:
+                    body = part.get_payload(decode=True).decode(errors='ignore')
+                elif 'attachment' in disp:
+                    filename = part.get_filename()
+                    if filename:
+                        path = os.path.join(attach_dir, filename)
+                        with open(path, 'wb') as f:
+                            f.write(part.get_payload(decode=True))
+                        files.append((filename, path))
+        else:
+            body = msg.get_payload(decode=True).decode(errors='ignore')
+
+        qr = QuoteRequest(sender=sender, subject=subject, body=body)
+        session.add(qr)
+        session.flush()
+        for fn, path in files:
+            session.add(Attachment(filename=fn, path=path, quote_request_id=qr.id))
+        session.commit()
+        mail.store(num, '+FLAGS', '\\Seen')
+
+    session.close()
+    mail.logout()

--- a/quote_manager/models.py
+++ b/quote_manager/models.py
@@ -1,0 +1,72 @@
+from sqlalchemy import Column, Integer, String, Text, Float, ForeignKey, Boolean
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+
+class QuoteRequest(Base):
+    __tablename__ = 'quote_requests'
+    id = Column(Integer, primary_key=True, index=True)
+    sender = Column(String)
+    subject = Column(String)
+    body = Column(Text)
+    attachments = relationship('Attachment', back_populates='quote_request')
+
+
+class Attachment(Base):
+    __tablename__ = 'attachments'
+    id = Column(Integer, primary_key=True)
+    filename = Column(String)
+    path = Column(String)
+    quote_request_id = Column(Integer, ForeignKey('quote_requests.id'))
+    quote_request = relationship('QuoteRequest', back_populates='attachments')
+
+
+class Supplier(Base):
+    __tablename__ = 'suppliers'
+    id = Column(Integer, primary_key=True)
+    name = Column(String, unique=True)
+    products = relationship('Product', back_populates='supplier')
+
+
+class Product(Base):
+    __tablename__ = 'products'
+    id = Column(Integer, primary_key=True)
+    supplier_id = Column(Integer, ForeignKey('suppliers.id'))
+    sku = Column(String, unique=True)
+    description = Column(String)
+    price = Column(Float)
+    lead_time = Column(Integer)
+    supplier = relationship('Supplier', back_populates='products')
+
+
+class Quote(Base):
+    __tablename__ = 'quotes'
+    id = Column(Integer, primary_key=True)
+    request_id = Column(Integer, ForeignKey('quote_requests.id'), nullable=True)
+    status = Column(String)
+    value = Column(Float)
+    margin = Column(Float)
+    pdf_link = Column(String)
+    items = relationship('QuoteItem', back_populates='quote')
+
+
+class QuoteItem(Base):
+    __tablename__ = 'quote_items'
+    id = Column(Integer, primary_key=True)
+    quote_id = Column(Integer, ForeignKey('quotes.id'))
+    product_id = Column(Integer, ForeignKey('products.id'))
+    quantity = Column(Integer)
+    quote = relationship('Quote', back_populates='items')
+    product = relationship('Product')
+    checklist = relationship('ChecklistItem', back_populates='quote_item', uselist=False)
+
+
+class ChecklistItem(Base):
+    __tablename__ = 'checklist_items'
+    id = Column(Integer, primary_key=True)
+    quote_item_id = Column(Integer, ForeignKey('quote_items.id'))
+    ordered = Column(Boolean, default=False)
+    received = Column(Boolean, default=False)
+    invoiced = Column(Boolean, default=False)
+    quote_item = relationship('QuoteItem', back_populates='checklist')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+SQLAlchemy
+fpdf2


### PR DESCRIPTION
## Summary
- add email watcher to record quote requests and attachments
- implement supplier, product, quote, and checklist models
- provide API endpoints and PDF delivery note generation

## Testing
- `python -m py_compile main.py quote_manager/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6892d25d909c832ca6c991e541b29489